### PR TITLE
Explicitly set the language type for .moc files to enable syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.moc linguist-language=Squirrel


### PR DESCRIPTION
<img width="1274" alt="Screenshot 2023-07-28 at 18 54 12" src="https://github.com/icrtouch/etal-ui-lib/assets/32024335/7947a7f8-f356-4f5f-ad2e-a49e1aec2405">
